### PR TITLE
Revert "Pin documentation job to nightly-2025-10-26"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,7 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          # https://github.com/rust-lang/rust/issues/148184
-          toolchain: nightly-2025-10-26
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
       - run: cargo docs-rs
 


### PR DESCRIPTION
Closes #4 &mdash; fixed upstream by https://github.com/rust-lang/rust/pull/148213 in nightly-2025-11-07.